### PR TITLE
Expose git_repo and hg_repo as fixtures

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,7 +1,5 @@
 import pytest
 
-import jaraco.path
-
 
 @pytest.fixture(autouse=True)
 def _isolate_home(tmp_home_dir):
@@ -25,20 +23,14 @@ rev2 = dict(
 @pytest.fixture
 def hg_repo(hg_repo):
     repo = hg_repo
-    jaraco.path.build(rev1)
-    repo._invoke('addremove')
-    repo._invoke('ci', '-m', 'committed')
-    jaraco.path.build(rev2)
-    repo._invoke('ci', '-m', 'added content')
+    repo.commit_tree(rev1, 'committed')
+    repo.commit_tree(rev2, 'added content')
     return repo
 
 
 @pytest.fixture
 def git_repo(git_repo):
     repo = git_repo
-    jaraco.path.build(rev1)
-    repo._invoke('add', '.')
-    repo._invoke('commit', '-m', 'committed')
-    jaraco.path.build(rev2)
-    repo._invoke('commit', '-am', 'added content')
+    repo.commit_tree(rev1, 'committed')
+    repo.commit_tree(rev2, 'added content')
     return repo

--- a/conftest.py
+++ b/conftest.py
@@ -1,25 +1,11 @@
 import pytest
 
 import jaraco.path
-from jaraco import vcs
 
 
 @pytest.fixture(autouse=True)
 def _isolate_home(tmp_home_dir):
     """Isolate the tests from a developer's VCS config."""
-
-
-def _ensure_present(repo):
-    try:
-        repo.version()
-    except Exception:
-        pytest.skip()
-
-
-@pytest.fixture
-def temp_work_dir(tmp_path, monkeypatch):
-    monkeypatch.chdir(tmp_path)
-    return tmp_path
 
 
 rev1 = dict(
@@ -37,10 +23,8 @@ rev2 = dict(
 
 
 @pytest.fixture
-def hg_repo(temp_work_dir):
-    repo = vcs.Mercurial()
-    _ensure_present(repo)
-    repo._invoke('init', '.')
+def hg_repo(hg_repo):
+    repo = hg_repo
     jaraco.path.build(rev1)
     repo._invoke('addremove')
     repo._invoke('ci', '-m', 'committed')
@@ -50,12 +34,8 @@ def hg_repo(temp_work_dir):
 
 
 @pytest.fixture
-def git_repo(temp_work_dir):
-    repo = vcs.Git()
-    _ensure_present(repo)
-    repo._invoke('init')
-    repo._invoke('config', 'user.email', 'vip@example.com')
-    repo._invoke('config', 'user.name', 'Important User')
+def git_repo(git_repo):
+    repo = git_repo
     jaraco.path.build(rev1)
     repo._invoke('add', '.')
     repo._invoke('commit', '-m', 'committed')

--- a/conftest.py
+++ b/conftest.py
@@ -1,5 +1,3 @@
-import pathlib
-
 import pytest
 
 import jaraco.path
@@ -11,9 +9,9 @@ def _isolate_home(tmp_home_dir):
     """Isolate the tests from a developer's VCS config."""
 
 
-def _ensure_present(mgr):
+def _ensure_present(repo):
     try:
-        mgr.version()
+        repo.version()
     except Exception:
         pytest.skip()
 
@@ -24,9 +22,16 @@ def temp_work_dir(tmp_path, monkeypatch):
     return tmp_path
 
 
-source_tree = dict(
+rev1 = dict(
     bar=dict(
         baz="",
+    ),
+)
+
+
+rev2 = dict(
+    bar=dict(
+        baz="content",
     ),
 )
 
@@ -36,10 +41,10 @@ def hg_repo(temp_work_dir):
     repo = vcs.Mercurial()
     _ensure_present(repo)
     repo._invoke('init', '.')
-    jaraco.path.build(source_tree)
+    jaraco.path.build(rev1)
     repo._invoke('addremove')
     repo._invoke('ci', '-m', 'committed')
-    pathlib.Path('bar/baz').write_text('content', encoding='utf-8')
+    jaraco.path.build(rev2)
     repo._invoke('ci', '-m', 'added content')
     return repo
 
@@ -51,9 +56,9 @@ def git_repo(temp_work_dir):
     repo._invoke('init')
     repo._invoke('config', 'user.email', 'vip@example.com')
     repo._invoke('config', 'user.name', 'Important User')
-    jaraco.path.build(source_tree)
+    jaraco.path.build(rev1)
     repo._invoke('add', '.')
     repo._invoke('commit', '-m', 'committed')
-    pathlib.Path('bar/baz').write_text('content', encoding='utf-8')
+    jaraco.path.build(rev2)
     repo._invoke('commit', '-am', 'added content')
     return repo

--- a/jaraco/vcs/base.py
+++ b/jaraco/vcs/base.py
@@ -134,3 +134,9 @@ class Repo(versioning.VersionManagement):
         Return the age of the repo.
         """
         raise NotImplementedError()
+
+    def commit_tree(self, spec, msg="committed"):
+        """
+        Apply the tree in spec and commit.
+        """
+        raise NotImplementedError()

--- a/jaraco/vcs/cmd.py
+++ b/jaraco/vcs/cmd.py
@@ -6,6 +6,7 @@ import re
 import subprocess
 
 import dateutil.parser
+import jaraco.path
 from tempora import utc
 
 
@@ -150,6 +151,11 @@ class Mercurial(Command):
     def _get_timestamp_str(self, rev):
         return self._invoke('log', '-l', '1', '--template', '{date|isodate}', '-r', rev)
 
+    def commit_tree(self, spec, message: str = 'committed'):
+        jaraco.path.build(spec)
+        self._invoke('addremove')
+        self._invoke('commit', '-m', message)
+
 
 class Git(Command):
     exe = 'git'
@@ -225,3 +231,8 @@ class Git(Command):
         proc.wait()
         proc.stdout.close()
         return utc.now() - dateutil.parser.parse(first_line)
+
+    def commit_tree(self, spec, message: str = 'committed'):
+        jaraco.path.build(spec)
+        self._invoke('add', '.')
+        self._invoke('commit', '-m', message)

--- a/jaraco/vcs/cmd.py
+++ b/jaraco/vcs/cmd.py
@@ -1,3 +1,4 @@
+import abc
 import collections
 import itertools
 import operator
@@ -13,7 +14,10 @@ from tempora import utc
 TaggedRevision = collections.namedtuple('TaggedRevision', 'tag revision')
 
 
-class Command:
+class Command(metaclass=abc.ABCMeta):
+    @abc.abstractmethod
+    def _invoke(self, *args): ...
+
     def is_valid(self):
         try:
             # Check if both command and repo are valid

--- a/jaraco/vcs/fixtures.py
+++ b/jaraco/vcs/fixtures.py
@@ -1,0 +1,34 @@
+import pytest
+
+from .. import vcs
+
+
+def _ensure_present(repo):
+    try:
+        repo.version()
+    except Exception:
+        pytest.skip()
+
+
+@pytest.fixture
+def temp_work_dir(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    return tmp_path
+
+
+@pytest.fixture
+def hg_repo(temp_work_dir):
+    repo = vcs.Mercurial()
+    _ensure_present(repo)
+    repo._invoke('init', '.')
+    return repo
+
+
+@pytest.fixture
+def git_repo(temp_work_dir):
+    repo = vcs.Git()
+    _ensure_present(repo)
+    repo._invoke('init')
+    repo._invoke('config', 'user.email', 'vip@example.com')
+    repo._invoke('config', 'user.name', 'Important User')
+    return repo

--- a/newsfragments/36.feature.rst
+++ b/newsfragments/36.feature.rst
@@ -1,0 +1,1 @@
+Presented hg_repo and git_repo as fixtures.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,3 +59,6 @@ doc = [
 ]
 
 [tool.setuptools_scm]
+
+[project.entry-points]
+pytest11 = {"jaraco.vcs.fixtures" = "jaraco.vcs.fixtures"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ dependencies = [
 	"jaraco.versioning",
 	"python-dateutil",
 	"tempora",
+	"jaraco.path",
 ]
 dynamic = ["version"]
 
@@ -43,7 +44,6 @@ test = [
 
 	# local
 	"pygments",
-	"jaraco.path",
 	"types-python-dateutil",
 	"pytest-home",
 ]


### PR DESCRIPTION
- **Rely on jaraco.path.build for building the two revs.**
- **Presented hg_repo and git_repo as fixtures.**
